### PR TITLE
Add responsive breakpoint foundation

### DIFF
--- a/actions/public-api.ts
+++ b/actions/public-api.ts
@@ -1,2 +1,3 @@
 export * from "./button";
 export * from "./icon-button";
+export * from "./theme-switch";

--- a/actions/theme-switch.ts
+++ b/actions/theme-switch.ts
@@ -1,0 +1,299 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  model,
+  output,
+  signal,
+} from "@angular/core";
+import { KentraIcon } from "@kentra-saas/ui-kit/icons";
+import {
+  KentraElementBase,
+  KentraThemeSwitchContract,
+  ThemeChangeEvent,
+  ThemeSwitchSize,
+  ThemeSwitchState,
+  ThemeSwitchTheme,
+  ThemeSwitchVariant,
+  themeSwitchStyleMap,
+} from "@kentra-saas/ui-kit";
+
+@Component({
+  selector: "k-theme-switch",
+  standalone: true,
+  imports: [KentraIcon],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    "[class]": "hostClasses()",
+    "[style]": "hostStyles()",
+    "[attr.aria-disabled]": "isInteractionBlocked() ? 'true' : null",
+  },
+  template: `
+    <button
+      class="button"
+      type="button"
+      role="switch"
+      [attr.aria-checked]="isDarkTheme()"
+      [attr.aria-label]="resolvedAriaLabel()"
+      [disabled]="isInteractionBlocked()"
+      (click)="toggleTheme()"
+      (pointerdown)="onPointerDown()"
+      (pointerup)="clearPressedState()"
+      (pointerleave)="clearPressedState()"
+      (pointercancel)="clearPressedState()"
+      (keydown)="onKeyDown($event)"
+      (keyup)="onKeyUp($event)"
+      (blur)="clearPressedState()"
+    >
+      <span class="icon icon-light" aria-hidden="true">
+        <k-icon name="sun" aria-hidden="true"></k-icon>
+      </span>
+      <span class="icon icon-dark" aria-hidden="true">
+        <k-icon name="moon" aria-hidden="true"></k-icon>
+      </span>
+      <span class="thumb" aria-hidden="true">
+        <k-icon [name]="thumbIcon()" aria-hidden="true"></k-icon>
+      </span>
+    </button>
+  `,
+  styles: `
+    :host {
+      display: inline-block;
+      inline-size: var(--k-theme-switch-track-width, auto);
+      max-inline-size: 100%;
+    }
+
+    .button {
+      box-sizing: border-box;
+      position: relative;
+      display: inline-grid;
+      grid-template-columns: 1fr 1fr;
+      align-items: center;
+      appearance: none;
+      -webkit-appearance: none;
+      inline-size: var(--k-theme-switch-track-width, 5rem);
+      block-size: var(--k-theme-switch-track-height, 2.5rem);
+      padding: var(--k-theme-switch-padding, 0.25rem);
+      border: var(--k-theme-switch-border-width, 1px) solid
+        var(--k-theme-switch-colors-border, transparent);
+      border-radius: var(--k-theme-switch-border-radius, 999px);
+      background: var(--k-theme-switch-colors-bg, transparent);
+      color: var(--k-theme-switch-colors-icon-muted, currentColor);
+      line-height: 1;
+      cursor: pointer;
+      user-select: none;
+      transition:
+        background var(--k-theme-switch-motion-duration, 0s)
+          var(--k-theme-switch-motion-easing, linear),
+        border-color var(--k-theme-switch-motion-duration, 0s)
+          var(--k-theme-switch-motion-easing, linear),
+        opacity var(--k-theme-switch-motion-duration, 0s)
+          var(--k-theme-switch-motion-easing, linear);
+    }
+
+    .button:focus-visible,
+    :host(.is-focus-visible) .button {
+      outline: 2px solid var(--k-theme-switch-focus-outline-color, transparent);
+      outline-offset: 2px;
+      box-shadow:
+        0 0 0 1px var(--k-theme-switch-focus-ring-color, transparent),
+        var(--k-theme-switch-focus-shadow, none);
+    }
+
+    .icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      inline-size: var(--k-theme-switch-thumb-size, 2rem);
+      block-size: var(--k-theme-switch-thumb-size, 2rem);
+      color: var(--k-theme-switch-colors-icon-muted, currentColor);
+      pointer-events: none;
+      z-index: 1;
+    }
+
+    .icon k-icon,
+    .thumb k-icon {
+      --k-icon-font-size: var(--k-theme-switch-icon-size, 1rem);
+      --k-icon-color: currentColor;
+    }
+
+    .icon-light {
+      color: var(--k-theme-switch-colors-icon-active, currentColor);
+    }
+
+    :host(.is-on) .icon-light {
+      color: var(--k-theme-switch-colors-icon-muted, currentColor);
+    }
+
+    :host(.is-on) .icon-dark {
+      color: var(--k-theme-switch-colors-icon-active, currentColor);
+    }
+
+    .thumb {
+      box-sizing: border-box;
+      position: absolute;
+      inset-inline-start: var(--k-theme-switch-padding, 0.25rem);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      inline-size: var(--k-theme-switch-thumb-size, 2rem);
+      block-size: var(--k-theme-switch-thumb-size, 2rem);
+      border: var(--k-theme-switch-border-width, 1px) solid
+        var(--k-theme-switch-colors-thumb-border, transparent);
+      border-radius: var(--k-theme-switch-border-radius, 999px);
+      background: var(--k-theme-switch-colors-thumb-bg, currentColor);
+      color: var(--k-theme-switch-colors-thumb-icon, currentColor);
+      transition: transform var(--k-theme-switch-motion-duration, 0s)
+        var(--k-theme-switch-motion-easing, linear);
+      z-index: 2;
+      pointer-events: none;
+    }
+
+    :host(.is-on) .thumb {
+      transform: translateX(
+        calc(
+          var(--k-theme-switch-track-width, 5rem) -
+            var(--k-theme-switch-thumb-size, 2rem) -
+            (var(--k-theme-switch-padding, 0.25rem) * 2) -
+            (var(--k-theme-switch-border-width, 1px) * 2)
+        )
+      );
+    }
+
+    :host(.is-disabled) .button,
+    :host([aria-disabled="true"]) .button {
+      cursor: not-allowed;
+      opacity: var(--k-theme-switch-disabled-opacity, 0.56);
+    }
+
+    @media (max-width: 64rem) {
+      :host(.k-theme-switch--size-lg) .button {
+        min-inline-size: var(
+          --k-theme-switch-tablet-track-width,
+          var(--k-theme-switch-track-width, 6rem)
+        );
+        min-block-size: var(
+          --k-theme-switch-tablet-track-height,
+          var(--k-theme-switch-track-height, 3rem)
+        );
+      }
+    }
+
+    @media (max-width: 48rem) {
+      .button {
+        min-inline-size: max(var(--k-theme-switch-track-width, 5rem), 4.75rem);
+        min-block-size: max(var(--k-theme-switch-track-height, 2.5rem), 2.75rem);
+      }
+    }
+  `,
+})
+export class KentraThemeSwitch
+  extends KentraElementBase
+  implements KentraThemeSwitchContract
+{
+  readonly variant = input<ThemeSwitchVariant>("default");
+  readonly size = input<ThemeSwitchSize>("md");
+  readonly theme = model<ThemeSwitchTheme>("light");
+  readonly disabled = input<boolean>(false);
+  readonly ariaLabel = input<string | null>(null);
+  readonly themeChanged = output<ThemeChangeEvent>();
+
+  protected readonly baseClass = themeSwitchStyleMap.baseClass;
+
+  private readonly isPressed = signal(false);
+
+  readonly isDarkTheme = computed(() => this.theme() === "dark");
+  readonly thumbIcon = computed(() => (this.isDarkTheme() ? "moon" : "sun"));
+  readonly resolvedAriaLabel = computed(
+    () => this.normalizeText(this.ariaLabel()) ?? "Dark theme",
+  );
+  readonly effectiveState = computed<ThemeSwitchState>(() => {
+    if (this.disabled()) {
+      return "disabled";
+    }
+
+    if (this.isPressed()) {
+      return "active";
+    }
+
+    return this.isDarkTheme() ? "on" : "default";
+  });
+  readonly isInteractionBlocked = computed(
+    () => this.effectiveState() === "disabled",
+  );
+
+  protected override styleValues() {
+    return {
+      variant: this.variant(),
+      size: this.size(),
+    };
+  }
+
+  protected override stateValues() {
+    const state = this.effectiveState();
+
+    return state === "default"
+      ? {}
+      : {
+          [state]: true,
+        };
+  }
+
+  toggleTheme(): void {
+    if (this.isInteractionBlocked()) {
+      return;
+    }
+
+    const previousTheme = this.theme();
+    const nextTheme = previousTheme === "dark" ? "light" : "dark";
+
+    this.theme.set(nextTheme);
+    this.themeChanged.emit({
+      theme: nextTheme,
+      previousTheme,
+      userTriggered: true,
+    });
+  }
+
+  onPointerDown(): void {
+    if (this.isInteractionBlocked()) {
+      return;
+    }
+
+    this.isPressed.set(true);
+  }
+
+  onKeyDown(event: KeyboardEvent): void {
+    if (this.isInteractionBlocked()) {
+      return;
+    }
+
+    if (event.key === " " || event.key === "Enter") {
+      this.isPressed.set(true);
+    }
+  }
+
+  onKeyUp(event: KeyboardEvent): void {
+    if (event.key === " " || event.key === "Enter") {
+      this.clearPressedState();
+    }
+  }
+
+  clearPressedState(): void {
+    if (!this.isPressed()) {
+      return;
+    }
+
+    this.isPressed.set(false);
+  }
+
+  private normalizeText(value: string | null): string | null {
+    if (value === null) {
+      return null;
+    }
+
+    const normalized = value.trim();
+    return normalized.length > 0 ? normalized : null;
+  }
+}

--- a/internal/components/buttons/index.ts
+++ b/internal/components/buttons/index.ts
@@ -1,2 +1,3 @@
 export * from "./button";
 export * from "./icon-button";
+export * from "./theme-switch";

--- a/internal/components/buttons/theme-switch/index.ts
+++ b/internal/components/buttons/theme-switch/index.ts
@@ -1,0 +1,8 @@
+export * from "./theme-switch.contract";
+export * from "./theme-switch.style-map";
+export type {
+  ThemeSwitchSize,
+  ThemeSwitchState,
+  ThemeSwitchTheme,
+  ThemeSwitchVariant,
+} from "./theme-switch.tokens";

--- a/internal/components/buttons/theme-switch/theme-switch.contract.ts
+++ b/internal/components/buttons/theme-switch/theme-switch.contract.ts
@@ -1,0 +1,35 @@
+import type { InputSignal, ModelSignal, OutputEmitterRef } from "@angular/core";
+import type {
+  ThemeSwitchSize,
+  ThemeSwitchTheme,
+  ThemeSwitchVariant,
+} from "./theme-switch.tokens";
+import type {
+  KentraSizeInput,
+  KentraVariantInput,
+} from "../../../core/contracts";
+
+export type ThemeChangeEvent = {
+  readonly theme: ThemeSwitchTheme;
+  readonly previousTheme: ThemeSwitchTheme;
+  readonly userTriggered: boolean;
+};
+
+interface KentraThemeSwitchInputs
+  extends KentraVariantInput<ThemeSwitchVariant>,
+    KentraSizeInput<ThemeSwitchSize> {
+  readonly theme: ModelSignal<ThemeSwitchTheme>;
+  readonly disabled: InputSignal<boolean>;
+  readonly ariaLabel: InputSignal<string | null>;
+}
+
+interface KentraThemeSwitchOutputs {
+  readonly themeChanged: OutputEmitterRef<ThemeChangeEvent>;
+}
+
+interface KentraThemeSwitchSlots {}
+
+export interface KentraThemeSwitchContract
+  extends KentraThemeSwitchInputs,
+    KentraThemeSwitchOutputs,
+    KentraThemeSwitchSlots {}

--- a/internal/components/buttons/theme-switch/theme-switch.style-map.ts
+++ b/internal/components/buttons/theme-switch/theme-switch.style-map.ts
@@ -1,0 +1,17 @@
+import { createComponentStyleMapFromTokens } from "../../../core/style-maps";
+import { themeSwitchTokens } from "./theme-switch.tokens";
+
+export const themeSwitchStyleMap = createComponentStyleMapFromTokens({
+  id: "theme-switch",
+  baseClass: "k-theme-switch",
+  tokens: themeSwitchTokens,
+  stateSelectors: {
+    default: "&",
+    hover: "&:hover, &.is-hover",
+    active: "&:active, &.is-active",
+    on: "&.is-on",
+    disabled: "&.is-disabled, &:disabled, &[aria-disabled='true']",
+    focusVisible:
+      "&:focus-within:not(.is-hover):not(.is-active):not(.is-disabled), &.is-focus-visible",
+  },
+});

--- a/internal/components/buttons/theme-switch/theme-switch.tokens.ts
+++ b/internal/components/buttons/theme-switch/theme-switch.tokens.ts
@@ -1,0 +1,115 @@
+import { tokens } from "../../../core/tokens";
+
+const baseThemeSwitchStyle = {
+  border: {
+    width: tokens.global.baseStyle.borderWidth.thin,
+    radius: tokens.global.baseStyle.radius.pill,
+  },
+  focus: {
+    ringColor: tokens.theme.interactionState.focus.ring,
+    outlineColor: tokens.theme.interactionState.focus.outline,
+    shadow: tokens.theme.elevation.shadow.focus,
+  },
+  motion: {
+    duration: tokens.global.baseStyle.motion.duration.fast,
+    easing: tokens.global.baseStyle.motion.ease.standard,
+  },
+  disabledOpacity: tokens.theme.interactionState.disabled.opacity,
+} as const;
+
+const defaultColors = {
+  bg: tokens.theme.colors.background.surface,
+  border: tokens.theme.colors.border.subtle,
+  thumbBg: tokens.theme.colors.background.elevated,
+  thumbBorder: tokens.theme.colors.border.default,
+  thumbIcon: tokens.theme.colors.text.primary,
+  iconActive: tokens.theme.colors.text.primary,
+  iconMuted: tokens.theme.colors.text.secondary,
+} as const;
+
+export const themeSwitchTokens = {
+  size: {
+    sm: {
+      trackWidth: "3.5rem",
+      trackHeight: tokens.global.baseStyle.space.step8,
+      padding: tokens.global.baseStyle.space.step1,
+      thumbSize: tokens.global.baseStyle.space.step6,
+      iconSize: tokens.global.icon.size.sm,
+    },
+    md: {
+      trackWidth: "4.5rem",
+      trackHeight: tokens.global.baseStyle.space.step10,
+      padding: tokens.global.baseStyle.space.step1,
+      thumbSize: tokens.global.baseStyle.space.step8,
+      iconSize: tokens.global.icon.size.sm,
+    },
+    lg: {
+      trackWidth: "5.5rem",
+      trackHeight: tokens.global.baseStyle.space.step12,
+      padding: tokens.global.baseStyle.space.step1,
+      thumbSize: tokens.global.baseStyle.space.step10,
+      iconSize: tokens.global.icon.size.md,
+    },
+  },
+  styles: {
+    base: baseThemeSwitchStyle,
+    default: {
+      default: {
+        colors: defaultColors,
+      },
+      hover: {
+        colors: {
+          bg: tokens.theme.interactionState.hoverOverlay,
+          border: tokens.theme.colors.border.default,
+          thumbBg: tokens.theme.colors.background.elevated,
+          thumbBorder: tokens.theme.colors.border.default,
+          thumbIcon: tokens.theme.colors.text.primary,
+          iconActive: tokens.theme.colors.text.primary,
+          iconMuted: tokens.theme.colors.text.secondary,
+        },
+      },
+      active: {
+        colors: {
+          bg: tokens.theme.interactionState.activeOverlay,
+          border: tokens.theme.colors.border.default,
+          thumbBg: tokens.theme.colors.background.elevated,
+          thumbBorder: tokens.theme.colors.border.default,
+          thumbIcon: tokens.theme.colors.text.primary,
+          iconActive: tokens.theme.colors.text.primary,
+          iconMuted: tokens.theme.colors.text.secondary,
+        },
+      },
+      on: {
+        colors: {
+          bg: tokens.theme.colors.background.surface,
+          border: tokens.theme.colors.border.default,
+          thumbBg: tokens.theme.colors.background.elevated,
+          thumbBorder: tokens.theme.colors.border.default,
+          thumbIcon: tokens.theme.colors.text.primary,
+          iconActive: tokens.theme.colors.text.primary,
+          iconMuted: tokens.theme.colors.text.secondary,
+        },
+      },
+      disabled: {
+        colors: {
+          bg: tokens.theme.interactionState.disabled.bg,
+          border: tokens.theme.interactionState.disabled.border,
+          thumbBg: tokens.theme.interactionState.disabled.bg,
+          thumbBorder: tokens.theme.interactionState.disabled.border,
+          thumbIcon: tokens.theme.interactionState.disabled.icon,
+          iconActive: tokens.theme.interactionState.disabled.icon,
+          iconMuted: tokens.theme.interactionState.disabled.icon,
+        },
+      },
+      focusVisible: {
+        // Focus visuals are handled by outline/ring on the runtime element.
+      },
+    },
+  },
+} as const;
+
+export type ThemeSwitchTokensContract = typeof themeSwitchTokens;
+export type ThemeSwitchTheme = "light" | "dark";
+export type ThemeSwitchSize = keyof ThemeSwitchTokensContract["size"];
+export type ThemeSwitchVariant = Exclude<keyof ThemeSwitchTokensContract["styles"], "base">;
+export type ThemeSwitchState = keyof ThemeSwitchTokensContract["styles"]["default"];

--- a/internal/core/responsive/breakpoint.service.ts
+++ b/internal/core/responsive/breakpoint.service.ts
@@ -1,0 +1,99 @@
+import { Injectable, NgZone, computed, inject, signal } from "@angular/core";
+import {
+  KentraBreakpoint,
+  KentraViewportRange,
+  kentraBreakpointOrder,
+  kentraBreakpointToPx,
+} from "./breakpoints";
+
+type BreakpointQuery = {
+  readonly breakpoint: KentraBreakpoint;
+  readonly query: string;
+};
+
+@Injectable({
+  providedIn: "root",
+})
+export class KentraBreakpointService {
+  private readonly zone = inject(NgZone);
+  private readonly activeBreakpointSignal = signal<KentraBreakpoint>("lg");
+  private readonly canObserveViewport =
+    typeof globalThis !== "undefined" &&
+    typeof globalThis.matchMedia === "function";
+  private readonly queries: readonly BreakpointQuery[] = kentraBreakpointOrder.map(
+    (breakpoint) => ({
+      breakpoint,
+      query: `(min-width: ${kentraBreakpointToPx(breakpoint)}px)`,
+    }),
+  );
+
+  readonly activeBreakpoint = this.activeBreakpointSignal.asReadonly();
+  readonly range = computed<KentraViewportRange>(() => {
+    const activeBreakpoint = this.activeBreakpoint();
+
+    if (activeBreakpoint === "xs" || activeBreakpoint === "sm") {
+      return "phone";
+    }
+
+    if (activeBreakpoint === "md") {
+      return "tablet";
+    }
+
+    if (activeBreakpoint === "lg") {
+      return "desktop";
+    }
+
+    return "wide";
+  });
+  readonly isPhone = computed(() => this.range() === "phone");
+  readonly isTablet = computed(() => this.range() === "tablet");
+  readonly isDesktop = computed(() => this.range() === "desktop" || this.range() === "wide");
+  readonly isWide = computed(() => this.range() === "wide");
+
+  constructor() {
+    if (!this.canObserveViewport) {
+      return;
+    }
+
+    this.zone.runOutsideAngular(() => {
+      const mediaQueries = this.queries.map(({ breakpoint, query }) => ({
+        breakpoint,
+        mediaQuery: globalThis.matchMedia(query),
+      }));
+
+      const update = () => {
+        const nextBreakpoint =
+          [...mediaQueries].reverse().find(({ mediaQuery }) => mediaQuery.matches)
+            ?.breakpoint ?? "xs";
+
+        this.zone.run(() => {
+          this.activeBreakpointSignal.set(nextBreakpoint);
+        });
+      };
+
+      for (const { mediaQuery } of mediaQueries) {
+        mediaQuery.addEventListener("change", update);
+      }
+
+      update();
+    });
+  }
+
+  isAtLeast(breakpoint: KentraBreakpoint): boolean {
+    return this.indexOf(this.activeBreakpoint()) >= this.indexOf(breakpoint);
+  }
+
+  isBelow(breakpoint: KentraBreakpoint): boolean {
+    return this.indexOf(this.activeBreakpoint()) < this.indexOf(breakpoint);
+  }
+
+  isBetween(from: KentraBreakpoint, to: KentraBreakpoint): boolean {
+    const activeIndex = this.indexOf(this.activeBreakpoint());
+
+    return activeIndex >= this.indexOf(from) && activeIndex < this.indexOf(to);
+  }
+
+  private indexOf(breakpoint: KentraBreakpoint): number {
+    return kentraBreakpointOrder.indexOf(breakpoint);
+  }
+}

--- a/internal/core/responsive/breakpoints.ts
+++ b/internal/core/responsive/breakpoints.ts
@@ -1,0 +1,31 @@
+export const kentraBreakpoints = {
+  xs: "0rem",
+  sm: "30rem",
+  md: "48rem",
+  lg: "64rem",
+  xl: "80rem",
+  "2xl": "96rem",
+} as const;
+
+export type KentraBreakpoint = keyof typeof kentraBreakpoints;
+
+export const kentraBreakpointOrder = [
+  "xs",
+  "sm",
+  "md",
+  "lg",
+  "xl",
+  "2xl",
+] as const satisfies readonly KentraBreakpoint[];
+
+export type KentraViewportRange = "phone" | "tablet" | "desktop" | "wide";
+
+export function kentraBreakpointToPx(breakpoint: KentraBreakpoint): number {
+  const value = kentraBreakpoints[breakpoint];
+
+  if (!value.endsWith("rem")) {
+    return Number.parseFloat(value);
+  }
+
+  return Number.parseFloat(value) * 16;
+}

--- a/internal/core/responsive/index.ts
+++ b/internal/core/responsive/index.ts
@@ -1,0 +1,2 @@
+export * from "./breakpoint.service";
+export * from "./breakpoints";

--- a/internal/core/style-maps/registry.ts
+++ b/internal/core/style-maps/registry.ts
@@ -2,6 +2,7 @@ import type { ComponentStyleMap } from "./types";
 import {
   buttonStyleMap,
   iconButtonStyleMap,
+  themeSwitchStyleMap,
   iconStyleMap,
   barChartStyleMap,
   chartContainerStyleMap,
@@ -46,6 +47,7 @@ import {
 export const componentStyleMaps = [
   buttonStyleMap,
   iconButtonStyleMap,
+  themeSwitchStyleMap,
   iconStyleMap,
   barChartStyleMap,
   chartContainerStyleMap,

--- a/internal/core/tokens/contracts/breakpoint-tokens.contract.ts
+++ b/internal/core/tokens/contracts/breakpoint-tokens.contract.ts
@@ -1,0 +1,12 @@
+import { token } from "./token-types";
+
+export const breakpointTokens = {
+  xs: token("--k-breakpoint-xs"),
+  sm: token("--k-breakpoint-sm"),
+  md: token("--k-breakpoint-md"),
+  lg: token("--k-breakpoint-lg"),
+  xl: token("--k-breakpoint-xl"),
+  "2xl": token("--k-breakpoint-2xl"),
+} as const;
+
+export type BreakpointTokensContract = typeof breakpointTokens;

--- a/internal/core/tokens/contracts/index.ts
+++ b/internal/core/tokens/contracts/index.ts
@@ -1,5 +1,6 @@
 export * from "./token-types";
 export * from "./base-style-tokens.contract";
+export * from "./breakpoint-tokens.contract";
 export * from "./typography-tokens.contract";
 export * from "./icon-tokens.contract";
 export * from "./color-palette-tokens.contract";

--- a/internal/core/tokens/token-bundle.ts
+++ b/internal/core/tokens/token-bundle.ts
@@ -1,6 +1,7 @@
 import {
   appBackgroundTokens,
   baseStyleTokens,
+  breakpointTokens,
   colorPaletteTokens,
   iconTokens,
   interactionStateTokens,
@@ -9,6 +10,7 @@ import {
   typographyTokens,
   type AppBackgroundTokensContract,
   type BaseStyleTokensContract,
+  type BreakpointTokensContract,
   type ColorPaletteTokensContract,
   type IconTokensContract,
   type InteractionStateTokensContract,
@@ -19,6 +21,7 @@ import {
 
 export interface GlobalTokensContract {
   readonly baseStyle: BaseStyleTokensContract;
+  readonly breakpoint: BreakpointTokensContract;
   readonly typography: TypographyTokensContract;
   readonly icon: IconTokensContract;
   readonly palette: ColorPaletteTokensContract;
@@ -33,6 +36,7 @@ export interface ThemeTokensContract {
 
 export const globalTokens = {
   baseStyle: baseStyleTokens,
+  breakpoint: breakpointTokens,
   typography: typographyTokens,
   icon: iconTokens,
   palette: colorPaletteTokens,

--- a/internal/index.ts
+++ b/internal/index.ts
@@ -1,2 +1,3 @@
 export * from "./components";
+export * from "./core/responsive";
 export { KentraElementBase } from './core/contracts/kentra-element.base'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kentra-saas/ui-kit",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": false,
   "description": "Kentra Angular UI Kit",
   "repository": {

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -3,11 +3,13 @@
 @use "themes/light";
 @use "tokens/base";
 @use "tokens/background";
+@use "tokens/breakpoints";
 @use "tokens/icon-set";
 @use "tokens/typography";
 @use "generated/components.generated";
 
 @include base.declare-base-style-tokens();
+@include breakpoints.declare-breakpoint-tokens();
 @include typography.declare-manrope-font-faces();
 @include typography.declare-typography-tokens();
 

--- a/styles/tokens/breakpoints.scss
+++ b/styles/tokens/breakpoints.scss
@@ -1,0 +1,69 @@
+@use "sass:list";
+@use "sass:map";
+
+$k-breakpoints: (
+  xs: 0rem,
+  sm: 30rem,
+  md: 48rem,
+  lg: 64rem,
+  xl: 80rem,
+  2xl: 96rem
+) !default;
+
+@function k-breakpoint($name) {
+  $value: map.get($k-breakpoints, $name);
+
+  @if $value == null {
+    @error "Unknown Kentra breakpoint `#{$name}`. Available breakpoints: #{map.keys($k-breakpoints)}.";
+  }
+
+  @return $value;
+}
+
+@mixin k-screen-up($name) {
+  @media (min-width: k-breakpoint($name)) {
+    @content;
+  }
+}
+
+@mixin k-screen-down($name) {
+  @media (max-width: calc(k-breakpoint($name) - 0.02px)) {
+    @content;
+  }
+}
+
+@mixin k-screen-between($from, $to) {
+  @media (min-width: k-breakpoint($from)) and (max-width: calc(k-breakpoint($to) - 0.02px)) {
+    @content;
+  }
+}
+
+@mixin k-screen-only($name) {
+  $keys: map-keys($k-breakpoints);
+  $index: list.index($keys, $name);
+
+  @if $index == null {
+    @error "Unknown Kentra breakpoint `#{$name}`. Available breakpoints: #{$keys}.";
+  }
+
+  @if $index == length($keys) {
+    @include k-screen-up($name) {
+      @content;
+    }
+  } @else {
+    @include k-screen-between($name, list.nth($keys, $index + 1)) {
+      @content;
+    }
+  }
+}
+
+@mixin declare-breakpoint-tokens() {
+  :root {
+    --k-breakpoint-xs: #{k-breakpoint(xs)};
+    --k-breakpoint-sm: #{k-breakpoint(sm)};
+    --k-breakpoint-md: #{k-breakpoint(md)};
+    --k-breakpoint-lg: #{k-breakpoint(lg)};
+    --k-breakpoint-xl: #{k-breakpoint(xl)};
+    --k-breakpoint-2xl: #{k-breakpoint(2xl)};
+  }
+}

--- a/tests/actions-components.spec.ts
+++ b/tests/actions-components.spec.ts
@@ -5,12 +5,14 @@ import { componentStyleMaps, generateComponentCss } from "../internal/core/style
 import {
   KentraButton,
   KentraIconButton,
+  KentraThemeSwitch,
 } from "../actions/public-api";
 
 describe("action components", () => {
   it("exports all action components from the actions entrypoint", () => {
     expect(typeof KentraButton).toBe("function");
     expect(typeof KentraIconButton).toBe("function");
+    expect(typeof KentraThemeSwitch).toBe("function");
   });
 
   it("maps button variants, sizes and states to dedicated runtime variables", () => {
@@ -46,5 +48,20 @@ describe("action components", () => {
     expect(css).toContain(".k-icon-button--variant-primary:focus-within:not(.is-hover):not(.is-active):not(.is-disabled), .k-icon-button--variant-primary.is-focus-visible {");
     expect(css).toContain(".k-icon-button--variant-primary.is-disabled, .k-icon-button--variant-primary:disabled, .k-icon-button--variant-primary[aria-disabled='true'] {");
     expect(css).toContain("--k-icon-button-colors-icon: var(--k-color-action-primary-text);");
+  });
+
+  it("maps theme-switch sizes, variants and states to dedicated runtime variables", () => {
+    const css = generateComponentCss(componentStyleMaps);
+
+    expect(css).toContain(".k-theme-switch--size-sm {");
+    expect(css).toContain(".k-theme-switch--size-md {");
+    expect(css).toContain(".k-theme-switch--size-lg {");
+    expect(css).toContain(".k-theme-switch--variant-default {");
+    expect(css).toContain(".k-theme-switch--variant-default.is-on {");
+    expect(css).toContain(".k-theme-switch--variant-default:hover, .k-theme-switch--variant-default.is-hover {");
+    expect(css).toContain(".k-theme-switch--variant-default:active, .k-theme-switch--variant-default.is-active {");
+    expect(css).toContain(".k-theme-switch--variant-default.is-disabled, .k-theme-switch--variant-default:disabled, .k-theme-switch--variant-default[aria-disabled='true'] {");
+    expect(css).toContain("--k-theme-switch-colors-bg: var(--k-color-bg-surface);");
+    expect(css).toContain("--k-theme-switch-colors-thumb-icon: var(--k-color-text-primary);");
   });
 });

--- a/tests/actions-quality-gates.spec.ts
+++ b/tests/actions-quality-gates.spec.ts
@@ -16,29 +16,36 @@ describe("action quality gates", () => {
   it("ensures responsive strategy for desktop, tablet and mobile", () => {
     const buttonSource = readProjectFile("actions/button.ts");
     const iconButtonSource = readProjectFile("actions/icon-button.ts");
+    const themeSwitchSource = readProjectFile("actions/theme-switch.ts");
 
     // Desktop baseline
     expect(buttonSource).toContain(":host {");
     expect(buttonSource).toContain(".button {");
     expect(iconButtonSource).toContain(":host {");
     expect(iconButtonSource).toContain(".button {");
+    expect(themeSwitchSource).toContain(":host {");
+    expect(themeSwitchSource).toContain(".button {");
 
     // Tablet and mobile adaptations
     expect(buttonSource).toContain("@media (max-width: 64rem)");
     expect(buttonSource).toContain("@media (max-width: 48rem)");
     expect(iconButtonSource).toContain("@media (max-width: 64rem)");
     expect(iconButtonSource).toContain("@media (max-width: 48rem)");
+    expect(themeSwitchSource).toContain("@media (max-width: 64rem)");
+    expect(themeSwitchSource).toContain("@media (max-width: 48rem)");
 
     // Touch-target safe mobile floor
     expect(buttonSource).toContain("min-block-size: max(var(--k-btn-min-height, 2.5rem), 2.75rem);");
     expect(iconButtonSource).toContain("min-inline-size: max(var(--k-icon-button-min-width, 2.5rem), 2.75rem);");
     expect(iconButtonSource).toContain("min-block-size: max(var(--k-icon-button-min-height, 2.5rem), 2.75rem);");
+    expect(themeSwitchSource).toContain("min-block-size: max(var(--k-theme-switch-track-height, 2.5rem), 2.75rem);");
   });
 
   it("ensures theme and parameter adaptation are wired", () => {
     const css = generateComponentCss(componentStyleMaps);
     const buttonSource = readProjectFile("actions/button.ts");
     const iconButtonSource = readProjectFile("actions/icon-button.ts");
+    const themeSwitchSource = readProjectFile("actions/theme-switch.ts");
 
     // Button parameter API
     expect(buttonSource).toContain("readonly variant = input<ButtonVariant>(\"primary\")");
@@ -59,6 +66,18 @@ describe("action quality gates", () => {
     expect(iconButtonSource).toContain("appearance: none;");
     expect(iconButtonSource).toContain("padding: 0;");
     expect(iconButtonSource).toContain("pointer-events: none;");
+
+    // ThemeSwitch parameter API
+    expect(themeSwitchSource).toContain("readonly variant = input<ThemeSwitchVariant>(\"default\")");
+    expect(themeSwitchSource).toContain("readonly size = input<ThemeSwitchSize>(\"md\")");
+    expect(themeSwitchSource).toContain("readonly theme = model<ThemeSwitchTheme>(\"light\")");
+    expect(themeSwitchSource).toContain("readonly disabled = input<boolean>(false)");
+    expect(themeSwitchSource).toContain("readonly themeChanged = output<ThemeChangeEvent>()");
+    expect(themeSwitchSource).toContain("imports: [KentraIcon]");
+    expect(themeSwitchSource).toContain("role=\"switch\"");
+    expect(themeSwitchSource).toContain("[attr.aria-checked]=\"isDarkTheme()\"");
+    expect(themeSwitchSource).toContain("<k-icon name=\"sun\" aria-hidden=\"true\"></k-icon>");
+    expect(themeSwitchSource).toContain("<k-icon name=\"moon\" aria-hidden=\"true\"></k-icon>");
 
     // Button theme and states
     expect(css).toContain(".k-button--variant-primary {");
@@ -81,5 +100,15 @@ describe("action quality gates", () => {
     expect(css).toContain(".k-icon-button--variant-primary:active, .k-icon-button--variant-primary.is-active {");
     expect(css).toContain(".k-icon-button--variant-primary.is-disabled, .k-icon-button--variant-primary:disabled, .k-icon-button--variant-primary[aria-disabled='true'] {");
     expect(css).toContain("--k-icon-button-icon-size: var(--k-space-6);");
+
+    // ThemeSwitch theme and states
+    expect(css).toContain(".k-theme-switch--variant-default {");
+    expect(css).toContain(".k-theme-switch--variant-default.is-on {");
+    expect(css).toContain("--k-theme-switch-colors-bg: var(--k-color-bg-surface);");
+    expect(css).toContain("--k-theme-switch-colors-border: var(--k-color-border-subtle);");
+    expect(css).toContain("--k-theme-switch-colors-thumb-bg: var(--k-color-bg-elevated);");
+    expect(css).toContain("--k-theme-switch-colors-thumb-icon: var(--k-color-text-primary);");
+    expect(css).toContain(".k-theme-switch--variant-default:focus-within:not(.is-hover):not(.is-active):not(.is-disabled), .k-theme-switch--variant-default.is-focus-visible {");
+    expect(css).toContain(".k-theme-switch--variant-default.is-disabled, .k-theme-switch--variant-default:disabled, .k-theme-switch--variant-default[aria-disabled='true'] {");
   });
 });

--- a/tests/responsive-quality-gates.spec.ts
+++ b/tests/responsive-quality-gates.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  KentraBreakpointService,
+  kentraBreakpointOrder,
+  kentraBreakpointToPx,
+  kentraBreakpoints,
+} from "../public-api";
+
+describe("responsive foundation", () => {
+  it("exports stable Kentra breakpoint constants", () => {
+    expect(kentraBreakpoints).toEqual({
+      xs: "0rem",
+      sm: "30rem",
+      md: "48rem",
+      lg: "64rem",
+      xl: "80rem",
+      "2xl": "96rem",
+    });
+    expect(kentraBreakpointOrder).toEqual(["xs", "sm", "md", "lg", "xl", "2xl"]);
+    expect(kentraBreakpointToPx("md")).toBe(768);
+    expect(kentraBreakpointToPx("lg")).toBe(1024);
+  });
+
+  it("exports the Angular breakpoint service from the root entrypoint", () => {
+    expect(typeof KentraBreakpointService).toBe("function");
+  });
+});

--- a/tests/scss-foundation-quality-gates.spec.ts
+++ b/tests/scss-foundation-quality-gates.spec.ts
@@ -51,17 +51,36 @@ describe("scss foundation quality gates", () => {
     expect(stylesEntry).toContain('@use "themes/dark";');
     expect(stylesEntry).toContain('@use "tokens/base";');
     expect(stylesEntry).toContain('@use "tokens/background";');
+    expect(stylesEntry).toContain('@use "tokens/breakpoints";');
     expect(stylesEntry).toContain('@use "tokens/icon-set";');
     expect(stylesEntry).toContain('@use "tokens/typography";');
     expect(stylesEntry).toContain('@use "generated/components.generated";');
 
     expect(stylesEntry).toContain("@include base.declare-base-style-tokens();");
+    expect(stylesEntry).toContain("@include breakpoints.declare-breakpoint-tokens();");
     expect(stylesEntry).toContain("@include typography.declare-manrope-font-faces();");
     expect(stylesEntry).toContain("@include typography.declare-typography-tokens();");
     expect(stylesEntry).toContain("@include icon-set.declare-phosphor-icon-font-face();");
     expect(stylesEntry).toContain("@include icon-set.declare-icon-set-tokens();");
     expect(stylesEntry).toContain("@include icon-set.apply-icon-foundation-class();");
     expect(stylesEntry).toContain("@include background.app-background();");
+  });
+
+  it("keeps responsive breakpoint mixins and runtime tokens stable", () => {
+    const breakpointSource = readProjectFile("styles/tokens/breakpoints.scss");
+
+    expect(breakpointSource).toContain("xs: 0rem");
+    expect(breakpointSource).toContain("sm: 30rem");
+    expect(breakpointSource).toContain("md: 48rem");
+    expect(breakpointSource).toContain("lg: 64rem");
+    expect(breakpointSource).toContain("xl: 80rem");
+    expect(breakpointSource).toContain("2xl: 96rem");
+    expect(breakpointSource).toContain("@mixin k-screen-up($name)");
+    expect(breakpointSource).toContain("@mixin k-screen-down($name)");
+    expect(breakpointSource).toContain("@mixin k-screen-between($from, $to)");
+    expect(breakpointSource).toContain("@mixin k-screen-only($name)");
+    expect(breakpointSource).toContain("@mixin declare-breakpoint-tokens()");
+    expect(breakpointSource).toContain("--k-breakpoint-lg: #{k-breakpoint(lg)};");
   });
 
   it("keeps theme switching selectors and light/dark contracts stable", () => {


### PR DESCRIPTION
## Summary
- add Kentra breakpoint constants and CSS tokens
- add SCSS media-query mixins for up/down/between/only ranges
- add SSR-safe Angular breakpoint service
- cover responsive foundation with quality-gate tests

## Verification
- npm run test:typecheck
- npm test
- npm run build