### PR TITLE
Export responsive SCSS entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The package bundles root styles and infrastructure for categorized component ent
 ## Public Imports
 - `@kentra-saas/ui-kit`
 - `@kentra-saas/ui-kit/styles.css`
+- `@kentra-saas/ui-kit/responsive.scss`
 - `@kentra-saas/ui-kit/layout`
 - `@kentra-saas/ui-kit/typography`
 - `@kentra-saas/ui-kit/actions`
@@ -66,6 +67,16 @@ Global styles import in consumer applications:
 
 ```scss
 @import "@kentra-saas/ui-kit/styles.css";
+```
+
+Responsive mixins import in component styles:
+
+```scss
+@use "@kentra-saas/ui-kit/responsive.scss" as responsive;
+
+@include responsive.k-screen-down(md) {
+  // mobile and small tablet styles
+}
 ```
 
 ## Release

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kentra-saas/ui-kit",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kentra-saas/ui-kit",
-      "version": "0.1.2",
+      "version": "0.1.4",
       "dependencies": {
         "chart.js": "^4.4.4",
         "tslib": "^2.7.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kentra-saas/ui-kit",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": false,
   "description": "Kentra Angular UI Kit",
   "repository": {
@@ -19,6 +19,7 @@
       "default": "./dist/fesm2022/kentra-saas-ui-kit.mjs"
     },
     "./styles.css": "./styles.css",
+    "./responsive.scss": "./styles/responsive.scss",
     "./layout": {
       "types": "./dist/types/kentra-saas-ui-kit-layout.d.ts",
       "default": "./dist/fesm2022/kentra-saas-ui-kit-layout.mjs"
@@ -67,6 +68,8 @@
   "files": [
     "dist",
     "styles.css",
+    "styles/responsive.scss",
+    "styles/tokens/breakpoints.scss",
     "assets"
   ],
   "publishConfig": {

--- a/styles/responsive.scss
+++ b/styles/responsive.scss
@@ -1,0 +1,1 @@
+@forward "tokens/breakpoints";

--- a/tests/layer-consumption-quality-gates.spec.ts
+++ b/tests/layer-consumption-quality-gates.spec.ts
@@ -30,6 +30,7 @@ const entrypoints = [
 const expectedPublicExports = [
   ".",
   "./styles.css",
+  "./responsive.scss",
   ...entrypoints.map((entrypoint) => `./${entrypoint}`),
 ] as const;
 

--- a/tests/scss-foundation-quality-gates.spec.ts
+++ b/tests/scss-foundation-quality-gates.spec.ts
@@ -68,6 +68,9 @@ describe("scss foundation quality gates", () => {
 
   it("keeps responsive breakpoint mixins and runtime tokens stable", () => {
     const breakpointSource = readProjectFile("styles/tokens/breakpoints.scss");
+    const responsiveEntry = readProjectFile("styles/responsive.scss");
+
+    expect(responsiveEntry).toContain('@forward "tokens/breakpoints";');
 
     expect(breakpointSource).toContain("xs: 0rem");
     expect(breakpointSource).toContain("sm: 30rem");


### PR DESCRIPTION
## Summary
- expose @kentra-saas/ui-kit/responsive.scss as a public package entrypoint
- include responsive SCSS source files in the published package
- document the responsive mixin import path and guard it with tests
- bump the package version to 0.1.4

## Verification
- npm test
- npm run build
- npm run pack:dry