### PR TITLE
Fix initial select value rendering

### DIFF
--- a/forms/select.ts
+++ b/forms/select.ts
@@ -66,7 +66,11 @@ type SelectionChangeEvent = {
         @for (group of optionGroups(); track group.label) {
           <optgroup [attr.label]="group.label">
             @for (option of group.options; track option.value) {
-              <option [value]="option.value" [disabled]="option.disabled ?? false">
+              <option
+                [value]="option.value"
+                [selected]="isOptionSelected(option.value)"
+                [disabled]="option.disabled ?? false"
+              >
                 {{ option.label }}
               </option>
             }
@@ -74,7 +78,11 @@ type SelectionChangeEvent = {
         }
 
         @for (option of options(); track option.value) {
-          <option [value]="option.value" [disabled]="option.disabled ?? false">
+          <option
+            [value]="option.value"
+            [selected]="isOptionSelected(option.value)"
+            [disabled]="option.disabled ?? false"
+          >
             {{ option.label }}
           </option>
         }
@@ -250,6 +258,10 @@ export class KentraSelect
       previousValue,
       userTriggered: true,
     });
+  }
+
+  isOptionSelected(value: string): boolean {
+    return value === this.resolvedValue();
   }
 
   onOpenIntent(): void {

--- a/tests/forms-quality-gates.spec.ts
+++ b/tests/forms-quality-gates.spec.ts
@@ -74,6 +74,8 @@ describe("form quality gates", () => {
     expect(selectSource).toContain("readonly ariaDescribedBy = input<string | null>(null)");
     expect(selectSource).toContain("imports: [KentraIcon]");
     expect(selectSource).toContain("<select");
+    expect(selectSource).toContain("[selected]=\"isOptionSelected(option.value)\"");
+    expect(selectSource).toContain("isOptionSelected(value: string): boolean");
     expect(selectSource).toContain("<k-icon class=\"icon\" name=\"caret-down\" aria-hidden=\"true\"></k-icon>");
     expect(checkboxSource).toContain("implements KentraCheckboxContract, FormCheckboxControl");
     expect(checkboxSource).toContain("readonly required = input(false, { transform: coerceBooleanInput })");


### PR DESCRIPTION
## Summary
- mark matching select options as selected for the current value
- cover the select value synchronization with a forms quality gate

## Verification
- npm test
- npm run test:typecheck
- npm run build